### PR TITLE
fix: intel release path

### DIFF
--- a/Casks/albert.rb
+++ b/Casks/albert.rb
@@ -1,5 +1,5 @@
 cask "albert" do
-  arch arm: "arm64", intel: "x86-64"
+  arch arm: "arm64", intel: "x86_64"
 
   # Dont touch, updated by github action
   version "0.27.5"


### PR DESCRIPTION
the release path should be `https://github.com/albertlauncher/albert/releases/download/v0.27.5/Albert-v0.27.5-x86_64.dmg`