### PR TITLE
fix: deprecated depends_on syntax

### DIFF
--- a/Casks/albert.rb
+++ b/Casks/albert.rb
@@ -16,7 +16,7 @@ cask "albert" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
   depends_on formula: "qt6"
   depends_on formula: "libqalculate"
   depends_on formula: "qtkeychain"


### PR DESCRIPTION
This PR fixes a warning that is caused by a deprecated `depends_on` syntax:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
Please report this issue to the albertlauncher/homebrew-albert tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/albertlauncher/homebrew-albert/Casks/albert.rb:19
```